### PR TITLE
Fix: add result definitions to all tests, sometimes passing

### DIFF
--- a/test/nytimes_test.rb
+++ b/test/nytimes_test.rb
@@ -11,20 +11,22 @@ class NytimesTest < Minitest::Test
   end
 
   def test_it_can_get_copyright
-    #Set your code to the local variable, "result"
-
+    result = @hash[:copyright]
     assert result, "Copyright (c) 2018 The New York Times Company. All Rights Reserved."
   end
 
   def test_it_can_get_array_of_stories
-    #Set your code to the local variable, "result"
-
+    result = @hash[:results]
     assert result.is_a? (Array)
     assert_equal 44, result.count
   end
 
   def test_it_can_get_all_stories_with_subsection_of_politics
-    #Set your code to the local variable, "result"
+
+    # With my implementation, I would run this file and kept getting overlapping scope issues?! test_it_can_get_array_of_stories failed with a length of 6, but would pass is line 29 was commented out. Issue was fixed using a new variable name in this test, but... why?
+
+    result = @hash[:results]
+    result.keep_if{ |story| story[:subsection] == "Politics"}
 
 
     assert result.is_a? (Array)


### PR DESCRIPTION
Tests are intermittently passing. I am not sure why. I am having no trouble accessing the right data from our hash, however it feels like I'm having scope problems between tests? Of the three I've written, all three use the variable `result`. It would seem that the manipulation of `result` in the third test is sometimes impacting the value of `result` in the second test, even though we're instantiating `result` separately in each test!? And then roughly 1 in 3 times the tests will just pass no problem. It almost makes me feel like I'm overlooking something that's making these tests order-dependent, but... I can't figure out what. 